### PR TITLE
Fix: Typo in part 13

### DIFF
--- a/13_Functions_pt2/Readme.md
+++ b/13_Functions_pt2/Readme.md
@@ -39,7 +39,7 @@ parentheses we must have exactly one argument. I want this to be used
 as both an expression and also as a standalone statement.
 
 So we'll start with the function call parser,
-`function_declaration()` in `expr.c`. When we get called, the identifier
+`funccall()` in `expr.c`. When we get called, the identifier
 has already been scanned in and the function's name is in the `Text`
 global variable:
 


### PR DESCRIPTION
Given the context, `funccall` is what ought to be here, not `function_declaration`.