### PR TITLE
docs: fix simple typo, identifer -> identifier

### DIFF
--- a/06_Variables/misc.c
+++ b/06_Variables/misc.c
@@ -21,7 +21,7 @@ void semi(void) {
   match(T_SEMI, ";");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/07_Comparisons/misc.c
+++ b/07_Comparisons/misc.c
@@ -21,7 +21,7 @@ void semi(void) {
   match(T_SEMI, ";");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/08_If_Statements/misc.c
+++ b/08_If_Statements/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/09_While_Loops/misc.c
+++ b/09_While_Loops/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/10_For_Loops/misc.c
+++ b/10_For_Loops/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/11_Functions_pt1/misc.c
+++ b/11_Functions_pt1/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/12_Types_pt1/misc.c
+++ b/12_Types_pt1/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/13_Functions_pt2/misc.c
+++ b/13_Functions_pt2/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/14_ARM_Platform/misc.c
+++ b/14_ARM_Platform/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/15_Pointers_pt1/misc.c
+++ b/15_Pointers_pt1/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/16_Global_Vars/Readme.md
+++ b/16_Global_Vars/Readme.md
@@ -118,7 +118,7 @@ call `global_declarations()`:
 ### `var_declaration()`
 
 The parsing of functions is much the same as before, except the code
-to scan the type and identifer are done elsewhere, and we receive the
+to scan the type and identifier are done elsewhere, and we receive the
 `type` as an argument.
 
 The parsing of variables also loses the type and identifier scanning code.

--- a/16_Global_Vars/misc.c
+++ b/16_Global_Vars/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/17_Scaling_Offsets/misc.c
+++ b/17_Scaling_Offsets/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/18_Lvalues_Revisited/misc.c
+++ b/18_Lvalues_Revisited/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/19_Arrays_pt1/misc.c
+++ b/19_Arrays_pt1/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/20_Char_Str_Literals/misc.c
+++ b/20_Char_Str_Literals/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/21_More_Operators/misc.c
+++ b/21_More_Operators/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/23_Local_Variables/misc.c
+++ b/23_Local_Variables/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/24_Function_Params/misc.c
+++ b/24_Function_Params/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/25_Function_Arguments/misc.c
+++ b/25_Function_Arguments/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/26_Prototypes/misc.c
+++ b/26_Prototypes/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/27_Testing_Errors/misc.c
+++ b/27_Testing_Errors/misc.c
@@ -41,7 +41,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/28_Runtime_Flags/misc.c
+++ b/28_Runtime_Flags/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/29_Refactoring/misc.c
+++ b/29_Refactoring/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/30_Design_Composites/Readme.md
+++ b/30_Design_Composites/Readme.md
@@ -285,8 +285,8 @@ After modifying and compiling the above program a few times, the answers are:
 
  + We can't redeclare `enum fred`. This seems to be the only place where
    we need to remember the name of an enum list.
- + We can reuse the enum list identifer `fred` as a variable name.
- + We can't reuse the enum value identifer `mary` in another enum list,
+ + We can reuse the enum list identifier `fred` as a variable name.
+ + We can't reuse the enum value identifier `mary` in another enum list,
    nor as a variable name.
  + We can assign enum value anywhere: they seem to be treated simply as
    names for literal integer values.

--- a/30_Design_Composites/misc.c
+++ b/30_Design_Composites/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/31_Struct_Declarations/misc.c
+++ b/31_Struct_Declarations/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/32_Struct_Access_pt1/Readme.md
+++ b/32_Struct_Access_pt1/Readme.md
@@ -105,7 +105,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a struct (or a union, later),
+  // Check that the identifier has been declared as a struct (or a union, later),
   // or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/32_Struct_Access_pt1/expr.c
+++ b/32_Struct_Access_pt1/expr.c
@@ -121,7 +121,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a struct (or a union, later),
+  // Check that the identifier has been declared as a struct (or a union, later),
   // or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/32_Struct_Access_pt1/misc.c
+++ b/32_Struct_Access_pt1/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/33_Unions/expr.c
+++ b/33_Unions/expr.c
@@ -121,7 +121,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/33_Unions/misc.c
+++ b/33_Unions/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/34_Enums_and_Typedefs/expr.c
+++ b/34_Enums_and_Typedefs/expr.c
@@ -121,7 +121,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/34_Enums_and_Typedefs/misc.c
+++ b/34_Enums_and_Typedefs/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/35_Preprocessor/expr.c
+++ b/35_Preprocessor/expr.c
@@ -121,7 +121,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/35_Preprocessor/misc.c
+++ b/35_Preprocessor/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/36_Break_Continue/expr.c
+++ b/36_Break_Continue/expr.c
@@ -121,7 +121,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/36_Break_Continue/misc.c
+++ b/36_Break_Continue/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/37_Switch/expr.c
+++ b/37_Switch/expr.c
@@ -121,7 +121,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/37_Switch/misc.c
+++ b/37_Switch/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/38_Dangling_Else/expr.c
+++ b/38_Dangling_Else/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/38_Dangling_Else/misc.c
+++ b/38_Dangling_Else/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/39_Var_Initialisation_pt1/expr.c
+++ b/39_Var_Initialisation_pt1/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/39_Var_Initialisation_pt1/misc.c
+++ b/39_Var_Initialisation_pt1/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/40_Var_Initialisation_pt2/expr.c
+++ b/40_Var_Initialisation_pt2/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/40_Var_Initialisation_pt2/misc.c
+++ b/40_Var_Initialisation_pt2/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/41_Local_Var_Init/expr.c
+++ b/41_Local_Var_Init/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/41_Local_Var_Init/misc.c
+++ b/41_Local_Var_Init/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/42_Casting/expr.c
+++ b/42_Casting/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/42_Casting/misc.c
+++ b/42_Casting/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/43_More_Operators/expr.c
+++ b/43_More_Operators/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/43_More_Operators/misc.c
+++ b/43_More_Operators/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/44_Fold_Optimisation/expr.c
+++ b/44_Fold_Optimisation/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/44_Fold_Optimisation/misc.c
+++ b/44_Fold_Optimisation/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/45_Globals_Again/expr.c
+++ b/45_Globals_Again/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/45_Globals_Again/misc.c
+++ b/45_Globals_Again/misc.c
@@ -42,7 +42,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/46_Void_Functions/expr.c
+++ b/46_Void_Functions/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/46_Void_Functions/misc.c
+++ b/46_Void_Functions/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/47_Sizeof/expr.c
+++ b/47_Sizeof/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/47_Sizeof/misc.c
+++ b/47_Sizeof/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/48_Static/expr.c
+++ b/48_Static/expr.c
@@ -116,7 +116,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/48_Static/misc.c
+++ b/48_Static/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/49_Ternary/expr.c
+++ b/49_Ternary/expr.c
@@ -117,7 +117,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/49_Ternary/misc.c
+++ b/49_Ternary/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/50_Mop_up_pt1/expr.c
+++ b/50_Mop_up_pt1/expr.c
@@ -117,7 +117,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/50_Mop_up_pt1/misc.c
+++ b/50_Mop_up_pt1/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/51_Arrays_pt2/expr.c
+++ b/51_Arrays_pt2/expr.c
@@ -126,7 +126,7 @@ static struct ASTnode *member_access(int withpointer) {
   struct symtable *typeptr;
   struct symtable *m;
 
-  // Check that the identifer has been declared as a
+  // Check that the identifier has been declared as a
   // struct/union or a struct/union pointer
   if ((compvar = findsymbol(Text)) == NULL)
     fatals("Undeclared variable", Text);

--- a/51_Arrays_pt2/misc.c
+++ b/51_Arrays_pt2/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/52_Pointers_pt2/Readme.md
+++ b/52_Pointers_pt2/Readme.md
@@ -17,7 +17,7 @@ a chain of pointers, e.g. something like the expression:
 ```
 
 The reason for this is that `primary()` is called and gets the value of
-the identifer at the beginning of the expression. If it sees a following
+the identifier at the beginning of the expression. If it sees a following
 postfix operator, it then calls `postfix()` to deal with it. `postfix()`
 deals with, for example, one `->` operator and returns. And that's it.
 There is no loop to follow a chain of `->` operators.

--- a/52_Pointers_pt2/misc.c
+++ b/52_Pointers_pt2/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/53_Mop_up_pt2/misc.c
+++ b/53_Mop_up_pt2/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/54_Reg_Spills/misc.c
+++ b/54_Reg_Spills/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/56_Local_Arrays/misc.c
+++ b/56_Local_Arrays/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/57_Mop_up_pt3/misc.c
+++ b/57_Mop_up_pt3/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/58_Ptr_Increments/misc.c
+++ b/58_Ptr_Increments/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/59_WDIW_pt1/misc.c
+++ b/59_WDIW_pt1/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/60_TripleTest/misc.c
+++ b/60_TripleTest/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }

--- a/62_Cleanup/misc.c
+++ b/62_Cleanup/misc.c
@@ -43,7 +43,7 @@ void rparen(void) {
   match(T_RPAREN, ")");
 }
 
-// Match an identifer and fetch the next token
+// Match an identifier and fetch the next token
 void ident(void) {
   match(T_IDENT, "identifier");
 }


### PR DESCRIPTION
There is a small typo in 06_Variables/misc.c, 07_Comparisons/misc.c, 08_If_Statements/misc.c, 09_While_Loops/misc.c, 10_For_Loops/misc.c, 11_Functions_pt1/misc.c, 12_Types_pt1/misc.c, 13_Functions_pt2/misc.c, 14_ARM_Platform/misc.c, 15_Pointers_pt1/misc.c, 16_Global_Vars/Readme.md, 16_Global_Vars/misc.c, 17_Scaling_Offsets/misc.c, 18_Lvalues_Revisited/misc.c, 19_Arrays_pt1/misc.c, 20_Char_Str_Literals/misc.c, 21_More_Operators/misc.c, 23_Local_Variables/misc.c, 24_Function_Params/misc.c, 25_Function_Arguments/misc.c, 26_Prototypes/misc.c, 27_Testing_Errors/misc.c, 28_Runtime_Flags/misc.c, 29_Refactoring/misc.c, 30_Design_Composites/Readme.md, 30_Design_Composites/misc.c, 31_Struct_Declarations/misc.c, 32_Struct_Access_pt1/Readme.md, 32_Struct_Access_pt1/expr.c, 32_Struct_Access_pt1/misc.c, 33_Unions/expr.c, 33_Unions/misc.c, 34_Enums_and_Typedefs/expr.c, 34_Enums_and_Typedefs/misc.c, 35_Preprocessor/expr.c, 35_Preprocessor/misc.c, 36_Break_Continue/expr.c, 36_Break_Continue/misc.c, 37_Switch/expr.c, 37_Switch/misc.c, 38_Dangling_Else/expr.c, 38_Dangling_Else/misc.c, 39_Var_Initialisation_pt1/expr.c, 39_Var_Initialisation_pt1/misc.c, 40_Var_Initialisation_pt2/expr.c, 40_Var_Initialisation_pt2/misc.c, 41_Local_Var_Init/expr.c, 41_Local_Var_Init/misc.c, 42_Casting/expr.c, 42_Casting/misc.c, 43_More_Operators/expr.c, 43_More_Operators/misc.c, 44_Fold_Optimisation/expr.c, 44_Fold_Optimisation/misc.c, 45_Globals_Again/expr.c, 45_Globals_Again/misc.c, 46_Void_Functions/expr.c, 46_Void_Functions/misc.c, 47_Sizeof/expr.c, 47_Sizeof/misc.c, 48_Static/expr.c, 48_Static/misc.c, 49_Ternary/expr.c, 49_Ternary/misc.c, 50_Mop_up_pt1/expr.c, 50_Mop_up_pt1/misc.c, 51_Arrays_pt2/expr.c, 51_Arrays_pt2/misc.c, 52_Pointers_pt2/Readme.md, 52_Pointers_pt2/misc.c, 53_Mop_up_pt2/misc.c, 54_Reg_Spills/misc.c, 56_Local_Arrays/misc.c, 57_Mop_up_pt3/misc.c, 58_Ptr_Increments/misc.c, 59_WDIW_pt1/misc.c, 60_TripleTest/misc.c, 62_Cleanup/misc.c.

Should read `identifier` rather than `identifer`.

