### PR TITLE
08_If_Statements, 09_While_Loops, 10_For_Loops: stmt.c, added '{' '}'…

### DIFF
--- a/08_If_Statements/stmt.c
+++ b/08_If_Statements/stmt.c
@@ -5,9 +5,9 @@
 // Parsing of statements
 // Copyright (c) 2019 Warren Toomey, GPL3
 
-// compound_statement:          // empty, i.e. no statement
-//      |      statement
-//      |      statement statements
+// compound_statement: '{' '}'          // empty, i.e. no statement
+//      |      '{' statement '}'
+//      |      '{' statement statements '}'
 //      ;
 //
 // statement: print_statement

--- a/09_While_Loops/stmt.c
+++ b/09_While_Loops/stmt.c
@@ -5,9 +5,9 @@
 // Parsing of statements
 // Copyright (c) 2019 Warren Toomey, GPL3
 
-// compound_statement:          // empty, i.e. no statement
-//      |      statement
-//      |      statement statements
+// compound_statement: '{' '}'          // empty, i.e. no statement
+//      |      '{' statement '}'
+//      |      '{' statement statements '}'
 //      ;
 //
 // statement: print_statement

--- a/10_For_Loops/stmt.c
+++ b/10_For_Loops/stmt.c
@@ -8,9 +8,9 @@
 // Prototypes
 static struct ASTnode *single_statement(void);
 
-// compound_statement:          // empty, i.e. no statement
-//      |      statement
-//      |      statement statements
+// compound_statement: '{' '}'          // empty, i.e. no statement
+//      |      '{' statement '}'
+//      |      '{' statement statements '}'
 //      ;
 //
 // statement: print_statement


### PR DESCRIPTION
08_If_Statements, 09_While_Loops, 10_For_Loops: stmt.c, added '{' '}' to BNF grammar comments. I've only gotten as far as 10, so I'm not sure how far the type spans. I tried to investigate further and saw the same "typo" but wasn't sure if that was on purpose.