### PR TITLE
typo cgcompare_and_set

### DIFF
--- a/08_If_Statements/cg.c
+++ b/08_If_Statements/cg.c
@@ -180,7 +180,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/09_While_Loops/cg.c
+++ b/09_While_Loops/cg.c
@@ -180,7 +180,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/10_For_Loops/cg.c
+++ b/10_For_Loops/cg.c
@@ -180,7 +180,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/11_Functions_pt1/cg.c
+++ b/11_Functions_pt1/cg.c
@@ -183,7 +183,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/12_Types_pt1/cg.c
+++ b/12_Types_pt1/cg.c
@@ -194,7 +194,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/13_Functions_pt2/cg.c
+++ b/13_Functions_pt2/cg.c
@@ -231,7 +231,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/14_ARM_Platform/cg.c
+++ b/14_ARM_Platform/cg.c
@@ -236,7 +236,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/15_Pointers_pt1/cg.c
+++ b/15_Pointers_pt1/cg.c
@@ -242,7 +242,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/15_Pointers_pt1/cg_arm.c
+++ b/15_Pointers_pt1/cg_arm.c
@@ -308,7 +308,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/16_Global_Vars/cg.c
+++ b/16_Global_Vars/cg.c
@@ -242,7 +242,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/16_Global_Vars/cg_arm.c
+++ b/16_Global_Vars/cg_arm.c
@@ -308,7 +308,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/17_Scaling_Offsets/cg.c
+++ b/17_Scaling_Offsets/cg.c
@@ -254,7 +254,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/17_Scaling_Offsets/cg_arm.c
+++ b/17_Scaling_Offsets/cg_arm.c
@@ -319,7 +319,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/18_Lvalues_Revisited/cg.c
+++ b/18_Lvalues_Revisited/cg.c
@@ -254,7 +254,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/18_Lvalues_Revisited/cg_arm.c
+++ b/18_Lvalues_Revisited/cg_arm.c
@@ -325,7 +325,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/19_Arrays_pt1/cg.c
+++ b/19_Arrays_pt1/cg.c
@@ -253,7 +253,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/19_Arrays_pt1/cg_arm.c
+++ b/19_Arrays_pt1/cg_arm.c
@@ -317,7 +317,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/20_Char_Str_Literals/cg.c
+++ b/20_Char_Str_Literals/cg.c
@@ -272,7 +272,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/20_Char_Str_Literals/cg_arm.c
+++ b/20_Char_Str_Literals/cg_arm.c
@@ -317,7 +317,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/21_More_Operators/cg.c
+++ b/21_More_Operators/cg.c
@@ -370,7 +370,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/21_More_Operators/cg_arm.c
+++ b/21_More_Operators/cg_arm.c
@@ -322,7 +322,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/23_Local_Variables/cg.c
+++ b/23_Local_Variables/cg.c
@@ -500,7 +500,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/23_Local_Variables/cg_arm.c
+++ b/23_Local_Variables/cg_arm.c
@@ -322,7 +322,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/24_Function_Params/cg.c
+++ b/24_Function_Params/cg.c
@@ -531,7 +531,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/24_Function_Params/cg_arm.c
+++ b/24_Function_Params/cg_arm.c
@@ -322,7 +322,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/25_Function_Arguments/cg.c
+++ b/25_Function_Arguments/cg.c
@@ -559,7 +559,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/25_Function_Arguments/cg_arm.c
+++ b/25_Function_Arguments/cg_arm.c
@@ -322,7 +322,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/26_Prototypes/cg.c
+++ b/26_Prototypes/cg.c
@@ -559,7 +559,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/26_Prototypes/cg_arm.c
+++ b/26_Prototypes/cg_arm.c
@@ -322,7 +322,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/27_Testing_Errors/cg.c
+++ b/27_Testing_Errors/cg.c
@@ -559,7 +559,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/27_Testing_Errors/cg_arm.c
+++ b/27_Testing_Errors/cg_arm.c
@@ -322,7 +322,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/28_Runtime_Flags/cg.c
+++ b/28_Runtime_Flags/cg.c
@@ -559,7 +559,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/28_Runtime_Flags/cg_arm.c
+++ b/28_Runtime_Flags/cg_arm.c
@@ -322,7 +322,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/29_Refactoring/cg.c
+++ b/29_Refactoring/cg.c
@@ -554,7 +554,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/29_Refactoring/cg_arm.c
+++ b/29_Refactoring/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/30_Design_Composites/cg.c
+++ b/30_Design_Composites/cg.c
@@ -541,7 +541,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/30_Design_Composites/cg_arm.c
+++ b/30_Design_Composites/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/31_Struct_Declarations/cg.c
+++ b/31_Struct_Declarations/cg.c
@@ -566,7 +566,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/31_Struct_Declarations/cg_arm.c
+++ b/31_Struct_Declarations/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/32_Struct_Access_pt1/cg.c
+++ b/32_Struct_Access_pt1/cg.c
@@ -566,7 +566,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/32_Struct_Access_pt1/cg_arm.c
+++ b/32_Struct_Access_pt1/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/33_Unions/cg.c
+++ b/33_Unions/cg.c
@@ -566,7 +566,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/33_Unions/cg_arm.c
+++ b/33_Unions/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/34_Enums_and_Typedefs/cg.c
+++ b/34_Enums_and_Typedefs/cg.c
@@ -566,7 +566,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/34_Enums_and_Typedefs/cg_arm.c
+++ b/34_Enums_and_Typedefs/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/35_Preprocessor/cg.c
+++ b/35_Preprocessor/cg.c
@@ -566,7 +566,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/35_Preprocessor/cg_arm.c
+++ b/35_Preprocessor/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/36_Break_Continue/cg.c
+++ b/36_Break_Continue/cg.c
@@ -566,7 +566,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/36_Break_Continue/cg_arm.c
+++ b/36_Break_Continue/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/37_Switch/cg.c
+++ b/37_Switch/cg.c
@@ -594,7 +594,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/37_Switch/cg_arm.c
+++ b/37_Switch/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/38_Dangling_Else/cg.c
+++ b/38_Dangling_Else/cg.c
@@ -594,7 +594,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/38_Dangling_Else/cg_arm.c
+++ b/38_Dangling_Else/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/39_Var_Initialisation_pt1/cg.c
+++ b/39_Var_Initialisation_pt1/cg.c
@@ -594,7 +594,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/39_Var_Initialisation_pt1/cg_arm.c
+++ b/39_Var_Initialisation_pt1/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/40_Var_Initialisation_pt2/cg.c
+++ b/40_Var_Initialisation_pt2/cg.c
@@ -616,7 +616,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/40_Var_Initialisation_pt2/cg_arm.c
+++ b/40_Var_Initialisation_pt2/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/41_Local_Var_Init/cg.c
+++ b/41_Local_Var_Init/cg.c
@@ -616,7 +616,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/41_Local_Var_Init/cg_arm.c
+++ b/41_Local_Var_Init/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/42_Casting/cg.c
+++ b/42_Casting/cg.c
@@ -618,7 +618,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/42_Casting/cg_arm.c
+++ b/42_Casting/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/43_More_Operators/cg.c
+++ b/43_More_Operators/cg.c
@@ -618,7 +618,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/43_More_Operators/cg_arm.c
+++ b/43_More_Operators/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/44_Fold_Optimisation/cg.c
+++ b/44_Fold_Optimisation/cg.c
@@ -618,7 +618,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/44_Fold_Optimisation/cg_arm.c
+++ b/44_Fold_Optimisation/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/45_Globals_Again/cg.c
+++ b/45_Globals_Again/cg.c
@@ -618,7 +618,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/45_Globals_Again/cg_arm.c
+++ b/45_Globals_Again/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/46_Void_Functions/cg.c
+++ b/46_Void_Functions/cg.c
@@ -618,7 +618,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/46_Void_Functions/cg_arm.c
+++ b/46_Void_Functions/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/47_Sizeof/cg.c
+++ b/47_Sizeof/cg.c
@@ -618,7 +618,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/47_Sizeof/cg_arm.c
+++ b/47_Sizeof/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/48_Static/cg.c
+++ b/48_Static/cg.c
@@ -620,7 +620,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/48_Static/cg_arm.c
+++ b/48_Static/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/49_Ternary/cg.c
+++ b/49_Ternary/cg.c
@@ -622,7 +622,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/49_Ternary/cg_arm.c
+++ b/49_Ternary/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/50_Mop_up_pt1/cg.c
+++ b/50_Mop_up_pt1/cg.c
@@ -676,7 +676,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/50_Mop_up_pt1/cg_arm.c
+++ b/50_Mop_up_pt1/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/51_Arrays_pt2/cg.c
+++ b/51_Arrays_pt2/cg.c
@@ -678,7 +678,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/51_Arrays_pt2/cg_arm.c
+++ b/51_Arrays_pt2/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/52_Pointers_pt2/cg.c
+++ b/52_Pointers_pt2/cg.c
@@ -682,7 +682,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/52_Pointers_pt2/cg_arm.c
+++ b/52_Pointers_pt2/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/53_Mop_up_pt2/cg.c
+++ b/53_Mop_up_pt2/cg.c
@@ -687,7 +687,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/53_Mop_up_pt2/cg_arm.c
+++ b/53_Mop_up_pt2/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/54_Reg_Spills/cg.c
+++ b/54_Reg_Spills/cg.c
@@ -703,7 +703,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/54_Reg_Spills/cg_arm.c
+++ b/54_Reg_Spills/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/56_Local_Arrays/cg.c
+++ b/56_Local_Arrays/cg.c
@@ -703,7 +703,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/56_Local_Arrays/cg_arm.c
+++ b/56_Local_Arrays/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/57_Mop_up_pt3/cg.c
+++ b/57_Mop_up_pt3/cg.c
@@ -706,7 +706,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/57_Mop_up_pt3/cg_arm.c
+++ b/57_Mop_up_pt3/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/58_Ptr_Increments/cg.c
+++ b/58_Ptr_Increments/cg.c
@@ -684,7 +684,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmpq\t%s, %s\n", reglist[r2], reglist[r1]);
   fprintf(Outfile, "\t%s\tL%d\n", invcmplist[ASTop - A_EQ], label);

--- a/58_Ptr_Increments/cg_arm.c
+++ b/58_Ptr_Increments/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/59_WDIW_pt1/cg.c
+++ b/59_WDIW_pt1/cg.c
@@ -720,7 +720,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label, int type) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   switch (size) {
   case 1:

--- a/59_WDIW_pt1/cg_arm.c
+++ b/59_WDIW_pt1/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/60_TripleTest/cg.c
+++ b/60_TripleTest/cg.c
@@ -720,7 +720,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label, int type) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   switch (size) {
   case 1:

--- a/60_TripleTest/cg_arm.c
+++ b/60_TripleTest/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/62_Cleanup/cg.c
+++ b/62_Cleanup/cg.c
@@ -730,7 +730,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label, int type) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   switch (size) {
   case 1:

--- a/62_Cleanup/cg_arm.c
+++ b/62_Cleanup/cg_arm.c
@@ -326,7 +326,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   fprintf(Outfile, "\tcmp\t%s, %s\n", reglist[r1], reglist[r2]);
   fprintf(Outfile, "\t%s\tL%d\n", brlist[ASTop - A_EQ], label);

--- a/63_QBE/cg.c
+++ b/63_QBE/cg.c
@@ -628,7 +628,7 @@ int cgcompare_and_jump(int ASTop, int r1, int r2, int label, int type) {
 
   // Check the range of the AST operation
   if (ASTop < A_EQ || ASTop > A_GE)
-    fatal("Bad ASTop in cgcompare_and_set()");
+    fatal("Bad ASTop in cgcompare_and_jump()");
 
   // Get a label for the next instruction
   label2 = genlabel();


### PR DESCRIPTION
cg.c and cg_arm.c in cgcompare_and_jump function: 
fix typo: "Bad ASTop in cgcompare_and_set()" -> "Bad ASTop in cgcompare_and_jump()"