### PR TITLE
Fix modify_type

### DIFF
--- a/53_Mop_up_pt2/Readme.md
+++ b/53_Mop_up_pt2/Readme.md
@@ -181,7 +181,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op==A_LOGOR || op==A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return(NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return(NULL);
     return (tree);
   }

--- a/53_Mop_up_pt2/Readme.md
+++ b/53_Mop_up_pt2/Readme.md
@@ -190,7 +190,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
 ```
 
 I've also realised that I've implemented `&&` and `||` incorrectly, so
-I'll have to fix that. Now now, but soon.
+I'll have to fix that. Not now, but soon.
 
 ## Return with No Value
 

--- a/53_Mop_up_pt2/types.c
+++ b/53_Mop_up_pt2/types.c
@@ -57,7 +57,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op==A_LOGOR || op==A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return(NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return(NULL);
     return (tree);
   }

--- a/54_Reg_Spills/types.c
+++ b/54_Reg_Spills/types.c
@@ -57,7 +57,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op==A_LOGOR || op==A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return(NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return(NULL);
     return (tree);
   }

--- a/56_Local_Arrays/types.c
+++ b/56_Local_Arrays/types.c
@@ -57,7 +57,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op==A_LOGOR || op==A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return(NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return(NULL);
     return (tree);
   }

--- a/57_Mop_up_pt3/types.c
+++ b/57_Mop_up_pt3/types.c
@@ -57,7 +57,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op==A_LOGOR || op==A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return(NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return(NULL);
     return (tree);
   }

--- a/58_Ptr_Increments/types.c
+++ b/58_Ptr_Increments/types.c
@@ -57,7 +57,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op==A_LOGOR || op==A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return(NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return(NULL);
     return (tree);
   }

--- a/59_WDIW_pt1/types.c
+++ b/59_WDIW_pt1/types.c
@@ -57,7 +57,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op==A_LOGOR || op==A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return(NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return(NULL);
     return (tree);
   }

--- a/60_TripleTest/types.c
+++ b/60_TripleTest/types.c
@@ -57,7 +57,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op==A_LOGOR || op==A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return(NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return(NULL);
     return (tree);
   }

--- a/62_Cleanup/types.c
+++ b/62_Cleanup/types.c
@@ -57,7 +57,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op==A_LOGOR || op==A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return(NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return(NULL);
     return (tree);
   }

--- a/63_QBE/types.c
+++ b/63_QBE/types.c
@@ -57,7 +57,7 @@ struct ASTnode *modify_type(struct ASTnode *tree, int rtype,
   if (op == A_LOGOR || op == A_LOGAND) {
     if (!inttype(ltype) && !ptrtype(ltype))
       return (NULL);
-    if (!inttype(ltype) && !ptrtype(rtype))
+    if (!inttype(rtype) && !ptrtype(rtype))
       return (NULL);
     return (tree);
   }


### PR DESCRIPTION
We check types at both sides of token `=` in `modify_type()` when the `op` is `A_LOGOR` or `A_LOGAND`, but it was misspelled to `ltype` when checking the right type.
Also, I fix `Now now` to `Not now` in README file.
fix #53 