### PR TITLE
Readme.md: fix test result

### DIFF
--- a/03_Precedence/Readme.md
+++ b/03_Precedence/Readme.md
@@ -409,7 +409,7 @@ $ make test2
  ./parser2 input05)
 15                                       # input01 result
 29                                       # input02 result
-syntax error on line 1, token 5          # input03 result
+syntax error on line 1, token 1          # input03 result
 Unrecognised character . on line 3       # input04 result
 Unrecognised character a on line 1       # input05 result
 


### PR DESCRIPTION
When parsing input03, the parser2 won't report syntax error until it reachs the plus sign.

```c
struct ASTnode *additive_expr(void) {
  struct ASTnode *left, *right;
  int tokentype;

  left = multiplicative_expr();

  tokentype = Token.token;
  if (tokentype == T_EOF)
    return (left);

  // Cache the '+' or '-' token type
  /** here the actual cached token is int literal '34' **/

  while (1) {
    // Fetch in the next integer literal
    scan(&Token);
    /** scan()s plus sign **/

    right = multiplicative_expr(); 
    /** primary() reports syntax error since Token is T_PLUS **/

    left = mkastnode(arithop(tokentype), left, right, 0);

    tokentype = Token.token;
    if (tokentype == T_EOF)
      break;
  }

  return (left);
}
```